### PR TITLE
Remove kubeconfig input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,10 +1,5 @@
 name: 'Install Linkerd'
 description: 'installs linkerd onto target cluster'
-inputs:
-  KUBECONFIG:
-    description: "path to kubeconfig"
-    required: false
-    default: "~/.kube/config"
 runs:
   using: "composite"
   steps:
@@ -12,5 +7,3 @@ runs:
       shell: bash
     - run: ${{ github.action_path }}/install-osm.sh
       shell: bash
-      env:
-        KUBECONFIG: ${{ inputs.KUBECONFIG }}

--- a/install-osm.sh
+++ b/install-osm.sh
@@ -6,7 +6,7 @@ OSM_VERSION=v0.11.0
 # Linux curl command only
 curl -sL "https://github.com/openservicemesh/osm/releases/download/$OSM_VERSION/osm-$OSM_VERSION-linux-amd64.tar.gz" | tar -vxzf -
 
-mv ./linux-amd64/osm /usr/local/bin/osm
+sudo mv ./linux-amd64/osm /usr/local/bin/osm
 osm version
 
 set +e

--- a/install-osm.sh
+++ b/install-osm.sh
@@ -13,6 +13,8 @@ set +e
 OSM_INSTALL=$(osm install 2>&1) || true
 set -e
 
+echo $OSM_INSTALL
+
 if grep -q "Error: Mesh osm already exists" <<< "$OSM_INSTALL"; then
     osm mesh upgrade
 fi

--- a/install-osm.sh
+++ b/install-osm.sh
@@ -6,15 +6,24 @@ OSM_VERSION=v0.11.0
 # Linux curl command only
 curl -sL "https://github.com/openservicemesh/osm/releases/download/$OSM_VERSION/osm-$OSM_VERSION-linux-amd64.tar.gz" | tar -vxzf -
 
-sudo mv ./linux-amd64/osm /usr/local/bin/osm
+mv ./linux-amd64/osm /usr/local/bin/osm
 osm version
 
 set +e
-OSM_INSTALL=$(osm install 2>&1) || true
+OSM_INSTALL=$(osm install 2>&1)
+exit_code=$?
 set -e
 
 echo $OSM_INSTALL
 
 if grep -q "Error: Mesh osm already exists" <<< "$OSM_INSTALL"; then
     osm mesh upgrade
+    exit 0
+fi
+
+# if the exit code is 1 otherwise, we should error out
+if (($exit_code > 0)); then
+    echo "Encountered some error in osm install, exiting"
+    echo "osm install error is: $OSM_INSTALL"
+    exit 1
 fi


### PR DESCRIPTION
When used in tandem with the azure/aks-set-context action, the kubeconfig environment variable is overwritten to a file that doesn't exist, causing the install to fail silently. Removing this input guarantees that the action will either use the correct kubeconfig, or get a nice error message and the action will fail properly